### PR TITLE
feat: 친구 목록 조회 기능 구현, fetch join 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.example'
-version = '0.0.4-SNAPSHOT'
+version = '0.0.5-SNAPSHOT'
 sourceCompatibility = '17'
 
 configurations {

--- a/src/main/java/com/example/chat/controller/AlarmApiController.java
+++ b/src/main/java/com/example/chat/controller/AlarmApiController.java
@@ -1,0 +1,31 @@
+package com.example.chat.controller;
+
+import com.example.chat.domain.User;
+import com.example.chat.dto.friend.FriendRequestDto;
+import com.example.chat.service.AlarmWriteService;
+import com.example.chat.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1/alarms")
+public class AlarmApiController {
+    private final UserService userService;
+    private final AlarmWriteService alarmWriteService;
+    @PostMapping("/request-friend")
+    public ResponseEntity requestFriend(HttpServletRequest request, @RequestBody FriendRequestDto requestDto) throws Exception {
+        User loginedUser = userService.getUserFromTokenInRequest(request);
+        alarmWriteService.makeFriendRequestAlarm(loginedUser, requestDto.getFriendedId());
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/chat/controller/FriendApiController.java
+++ b/src/main/java/com/example/chat/controller/FriendApiController.java
@@ -1,0 +1,39 @@
+package com.example.chat.controller;
+
+import com.example.chat.domain.User;
+import com.example.chat.dto.friend.FriendResponseDto;
+import com.example.chat.dto.friend.FriendResponseDtoList;
+import com.example.chat.service.FriendReadService;
+import com.example.chat.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/friends")
+public class FriendApiController {
+    private final UserService userService;
+    private final FriendReadService friendReadService;
+    @GetMapping
+    public ResponseEntity getFriendList(HttpServletRequest request) {
+        try {
+            User loginedUser = userService.getUserFromTokenInRequest(request);
+            List<FriendResponseDto> responseDtoList = friendReadService.getFriendListDtoFromUserId(loginedUser.getId());
+            FriendResponseDtoList response = new FriendResponseDtoList(responseDtoList);
+            return new ResponseEntity(response, HttpStatus.OK);
+        } catch (Exception e) {
+            log.error(e + "| 친구목록 조히에 실패했습니다.");
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/example/chat/domain/Alarm.java
+++ b/src/main/java/com/example/chat/domain/Alarm.java
@@ -20,11 +20,11 @@ public class Alarm extends BaseTime {
 
     private String content; // 알람내용
     @Enumerated(EnumType.STRING)
-    private AlarmType alarmType;
+    private AlarmType alarmType; // CHAT, FRIEND, INVITE, TIME
 
     @Column(columnDefinition="tinyint(1) default 0")
     private Boolean isChecked; // 0: no, 1: yes
 //
-//    / 한명이 여러개의 알림을 보낼 수 있고, 수신자의 id도 알아야함..
+//    / 한명이 여러개의 알림을 보낼 수 있고, 수신자의 id도 알아야함.
 
 }

--- a/src/main/java/com/example/chat/domain/Friend.java
+++ b/src/main/java/com/example/chat/domain/Friend.java
@@ -21,13 +21,10 @@ public class Friend extends BaseTime {
     @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "friend_id")
     private Long id;
-
-    private Long friendedId; // 친구신청 당한 사람
+    private Long friendedId; // 친구인 사용자 id
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private User user; // 친구신청 한 사람 -> 한 사람이 여려명에게 친구신청을 보낼 수 있기 때문
-
+    private User user; // 사용자 본인 id -> 한 사람이 여려명에게 친구신청을 보낼 수 있기 때문
     @Enumerated(EnumType.STRING)
-    private FriendStatus friendStatus; // BLOCK(차단), HIDE(숨김), FAVORITE(즐겨찾기)
-
+    private FriendStatus friendStatus; // BLOCK(차단), HIDE(숨김), FAVORITE(즐겨찾기), NORMAL(일반)
 }

--- a/src/main/java/com/example/chat/domain/enums/FriendStatus.java
+++ b/src/main/java/com/example/chat/domain/enums/FriendStatus.java
@@ -1,5 +1,5 @@
 package com.example.chat.domain.enums;
 
 public enum FriendStatus {
-    BLOCK, HIDE, FAVORITE
+    BLOCK, HIDE, FAVORITE, NORMAL
 }

--- a/src/main/java/com/example/chat/dto/friend/FriendRequestDto.java
+++ b/src/main/java/com/example/chat/dto/friend/FriendRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.chat.dto.friend;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FriendRequestDto {
+    private Long friendedId;
+}

--- a/src/main/java/com/example/chat/dto/friend/FriendResponseDto.java
+++ b/src/main/java/com/example/chat/dto/friend/FriendResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.chat.dto.friend;
+
+import com.example.chat.domain.Friend;
+import com.example.chat.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FriendResponseDto {
+    private Long userId;
+    private String userName;
+    private String userImgUrl;
+
+    public static FriendResponseDto toDto(User user) {
+
+        return FriendResponseDto.builder()
+                .userId(user.getId())
+                .userName(user.getUsername())
+                .userImgUrl(user.getImgUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/example/chat/dto/friend/FriendResponseDtoList.java
+++ b/src/main/java/com/example/chat/dto/friend/FriendResponseDtoList.java
@@ -1,0 +1,15 @@
+package com.example.chat.dto.friend;
+
+import com.example.chat.domain.Friend;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FriendResponseDtoList {
+    List<FriendResponseDto> friendDtoList;
+}

--- a/src/main/java/com/example/chat/repository/AlarmRepository.java
+++ b/src/main/java/com/example/chat/repository/AlarmRepository.java
@@ -1,0 +1,9 @@
+package com.example.chat.repository;
+
+import com.example.chat.domain.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+}

--- a/src/main/java/com/example/chat/repository/FriendRepository.java
+++ b/src/main/java/com/example/chat/repository/FriendRepository.java
@@ -1,0 +1,16 @@
+package com.example.chat.repository;
+
+import com.example.chat.domain.Friend;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+    @Query("select f from Friend f join fetch f.user u where u.id = :userId")
+    List<Friend> findAllByUserId(Long userId);
+
+}

--- a/src/main/java/com/example/chat/service/AlarmWriteService.java
+++ b/src/main/java/com/example/chat/service/AlarmWriteService.java
@@ -1,0 +1,27 @@
+package com.example.chat.service;
+
+import com.example.chat.domain.Alarm;
+import com.example.chat.domain.User;
+import com.example.chat.domain.enums.AlarmType;
+import com.example.chat.repository.AlarmRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class AlarmWriteService {
+    private final AlarmRepository alarmRepository;
+//    / 누가 누구한테 보내는지도 정보가 있어야댐~
+    public void makeFriendRequestAlarm(User loginedUser, Long friendedId) {
+        Alarm newAlarm = Alarm.builder()
+                            .content("")
+                            .alarmType(AlarmType.FRIEND)
+                            .isChecked(false)
+                            .build();
+        alarmRepository.save(newAlarm);
+    }
+}

--- a/src/main/java/com/example/chat/service/FriendReadService.java
+++ b/src/main/java/com/example/chat/service/FriendReadService.java
@@ -1,0 +1,37 @@
+package com.example.chat.service;
+
+import com.example.chat.domain.Friend;
+import com.example.chat.domain.User;
+import com.example.chat.dto.friend.FriendResponseDto;
+import com.example.chat.repository.FriendRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FriendReadService {
+    private final FriendRepository friendRepository;
+    private final UserService userService;
+
+    public List<FriendResponseDto> getFriendListDtoFromUserId(Long loginedUserId) {
+        try {
+            List<FriendResponseDto> friendListResponseDtoList = new ArrayList<>();
+            List<Friend> allWithUserId = friendRepository.findAllByUserId(loginedUserId);
+            for (Friend friend : allWithUserId) {
+                User findUser = userService.getUserById(friend.getFriendedId());
+                friendListResponseDtoList.add(FriendResponseDto.toDto(findUser));
+            }
+            return friendListResponseDtoList;
+        } catch (Exception e) {
+            log.error(e + " | 친구목록 조회에 실패했습니다.");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
+ FriendReadService 클래스에 `List<FriendResponseDto> getFriendListDtoFromUserId(Long: loginedUserId)` 매서드를 구현함
+ `Lit<Friend> friendRepository.findAllByUserId(Long: loginedUserId)` 매서드에서 query작성 시 fetch join 사용하여 Friend엔티티와 관련있는 User엔티티를 조인함
+ 이를 통해 User의 친구들의 username, imgUrl을 조회할 때 **N+1쿼리가 나가는 것을 방지**할 수 있었음